### PR TITLE
Skip dex-preopting prebuilts.

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -36,6 +36,7 @@ ifeq ($(HOST_OS),linux)
     endif
   endif
 endif
+DONT_DEXPREOPT_PREBUILTS := true
 
 # Filesystem
 BOARD_BOOTIMAGE_PARTITION_SIZE     := 16777216


### PR DESCRIPTION
Bacon is close to the system image size limit.

Bug: 17772057
Change-Id: Ibc12f640f3cce32166c26a1c2fb45a650b439f29